### PR TITLE
Improve documentation code examples

### DIFF
--- a/docs/api/context-mesh.md
+++ b/docs/api/context-mesh.md
@@ -82,6 +82,10 @@ You can use one or combine multiple routing methods:
 #### Examples
 
 ```python
+from syntha import ContextMesh
+
+context = ContextMesh(user_id="user123")
+
 # Global context (available to all agents)
 context.push("api_status", "healthy")
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -110,6 +110,10 @@ prefs = context.get("user_preferences", "agent_name")
 
 #### Topic-Based Routing
 ```python
+from syntha import ContextMesh
+
+context = ContextMesh(user_id="user123")
+
 # Agent subscribes to topics
 context.register_agent_topics("SalesAgent", ["sales", "customers"])
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -34,6 +34,9 @@ Syntha provides three ways to route context between agents:
 Context accessible by all agents in the system.
 
 ```python
+from syntha import ContextMesh
+
+context = ContextMesh(user_id="user123")
 # Available to all agents
 context.push("api_status", "healthy")
 ```
@@ -44,6 +47,9 @@ context.push("api_status", "healthy")
 Context targeted to specific named agents.
 
 ```python
+from syntha import ContextMesh
+
+context = ContextMesh(user_id="user123")
 # Only accessible by "Agent1" and "Agent2"  
 context.push("private_data", {"key": "value"}, subscribers=["Agent1", "Agent2"])
 ```
@@ -54,6 +60,9 @@ context.push("private_data", {"key": "value"}, subscribers=["Agent1", "Agent2"])
 Context broadcast to agents subscribed to specific topics.
 
 ```python
+from syntha import ContextMesh
+
+context = ContextMesh(user_id="user123")
 # Available to agents subscribed to "sales" or "analytics" topics
 context.push("revenue_data", {"q4": 150000}, topics=["sales", "analytics"])
 ```
@@ -65,6 +74,8 @@ context.push("revenue_data", {"q4": 150000}, topics=["sales", "analytics"])
 One of Syntha's most important features is complete user isolation. Each user gets their own context space that's invisible to other users.
 
 ```python
+from syntha import ContextMesh
+
 # User A's context
 context_a = ContextMesh(user_id="user_a")
 context_a.push("secret", "user_a_data")
@@ -92,6 +103,9 @@ context_b.push("secret", "user_b_data")
 Context items can automatically expire after a specified duration:
 
 ```python
+from syntha import ContextMesh
+
+context = ContextMesh(user_id="user123")
 # Expires after 1 hour (3600 seconds)
 context.push("temporary_token", "abc123", ttl=3600)
 ```
@@ -125,11 +139,14 @@ context = ContextMesh(
 Expired items are automatically cleaned up to prevent memory bloat:
 
 ```python
+from syntha import ContextMesh
+
+context = ContextMesh(user_id="user123")
 # Manual cleanup
 context.cleanup_expired()
 
 # Automatic cleanup (default: every 5 minutes)
-context = ContextMesh(auto_cleanup=True)
+context = ContextMesh(user_id="user123", auto_cleanup=True)
 ```
 
 ## Agent Integration Patterns
@@ -166,8 +183,10 @@ system_prompt = build_system_prompt("SalesAgent", context)
 Syntha maintains indexes for fast context lookups:
 
 ```python
+from syntha import ContextMesh
+
 # Enable indexing for better performance (default)
-context = ContextMesh(enable_indexing=True)
+context = ContextMesh(user_id="user123", enable_indexing=True)
 ```
 
 ### Database Backends
@@ -180,7 +199,10 @@ Choose the right backend for your scale:
 Control memory usage with cleanup settings:
 
 ```python
+from syntha import ContextMesh
+
 context = ContextMesh(
+    user_id="user123",
     auto_cleanup=True,        # Automatic cleanup
     cleanup_interval=300      # Every 5 minutes
 )

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -410,6 +410,10 @@ context = ContextMesh(
 
 ### 3. Organize Topics by Domain
 ```python
+from syntha import ContextMesh
+
+context = ContextMesh(user_id="user123")
+
 # ✅ GOOD - Clear domain separation
 context.register_agent_topics("SalesAgent", ["sales", "customers", "leads"])
 context.register_agent_topics("SupportAgent", ["support", "customers", "issues"])

--- a/docs/guides/overview.md
+++ b/docs/guides/overview.md
@@ -33,6 +33,8 @@ Syntha solves these problems with a **Context Mesh** - a shared knowledge layer 
 **🔐 Critical Security Principle**: Every production deployment MUST use user isolation.
 
 ```python
+from syntha import ContextMesh
+
 # ✅ CORRECT - Each user gets their own isolated context
 user1_context = ContextMesh(user_id="user_123")
 user2_context = ContextMesh(user_id="user_456")
@@ -56,11 +58,15 @@ Syntha provides two powerful routing mechanisms:
 Agents subscribe to topics they care about, and context automatically routes to interested parties.
 
 ```python
+from syntha import ContextMesh
+
+context = ContextMesh(user_id="user123")
 # Agents declare their interests
 context.register_agent_topics("SalesAgent", ["sales", "customers"])
 context.register_agent_topics("SupportAgent", ["support", "customers"])
 
 # Push context to topics - all subscribers automatically receive it
+customer_data = {"name": "Acme Corp", "value": 50000}
 context.push("new_customer", customer_data, topics=["customers"])
 ```
 
@@ -70,7 +76,11 @@ context.push("new_customer", customer_data, topics=["customers"])
 Context goes directly to specific named agents.
 
 ```python
+from syntha import ContextMesh
+
+context = ContextMesh(user_id="user123")
 # Private communication between specific agents
+secret_data = {"api_key": "sk-abc123", "endpoint": "https://api.example.com"}
 context.push("api_credentials", secret_data, subscribers=["AuthAgent", "AdminAgent"])
 ```
 
@@ -82,6 +92,9 @@ context.push("api_credentials", secret_data, subscribers=["AuthAgent", "AdminAge
 Agents actively manage context through function calls:
 
 ```python
+from syntha import ContextMesh, ToolHandler
+
+context = ContextMesh(user_id="user123")
 handler = ToolHandler(context, "MyAgent")
 result = handler.handle_tool_call("subscribe_to_topics", topics=["sales"])
 result = handler.handle_tool_call("push_context", key="data", value="info", topics=["sales"])
@@ -98,6 +111,9 @@ result = handler.handle_tool_call("push_context", key="data", value="info", topi
 Context automatically appears in agent prompts:
 
 ```python
+from syntha import ContextMesh, build_system_prompt
+
+context = ContextMesh(user_id="user123")
 system_prompt = build_system_prompt("MyAgent", context)
 # Prompt now includes all accessible context
 ```
@@ -130,6 +146,8 @@ When you give tools to agents, here's what each one is for:
 **Simple Rule**: Use Context Mesh persistence instead of separate databases.
 
 ```python
+from syntha import ContextMesh
+
 # ✅ RECOMMENDED - Context Mesh handles persistence
 context = ContextMesh(
     user_id="user123",


### PR DESCRIPTION
## Description

This pull request improves the usability of code examples across the documentation by making them fully copy-pastable and runnable out-of-the-box. This includes adding necessary imports, initializing `ContextMesh` instances, and ensuring proper `user_id` parameters are used for clarity and security.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update (changes to documentation only)
- [ ] 🔧 Refactoring (code changes that neither fix bugs nor add features)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements

## Related Issues

N/A

## Changes Made

- Added missing `import` statements (e.g., `ContextMesh`, `ToolHandler`, `build_system_prompt`) to various code examples.
- Initialized `ContextMesh` instances in examples where `context` was used without prior definition.
- Ensured `user_id` parameter is included in `ContextMesh` constructor calls for security best practices and example completeness.
- Added explicit variable definitions (e.g., `customer_data`, `secret_data`) to make examples more realistic and copy-pastable.
- Modified the following documentation files:
    - `docs/api/context-mesh.md`
    - `docs/api/overview.md`
    - `docs/core-concepts.md`
    - `docs/guides/context.md`
    - `docs/guides/overview.md`

## Testing

- [ ] All existing tests pass
- [ ] Added new tests for changes
- [ ] Updated existing tests if needed
- [x] Manual testing completed
    - All modified code examples were manually executed and verified to work correctly.

### Test Coverage

```bash
# Not applicable for documentation changes
```

## Code Quality

- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] Code is properly documented (This PR *is* a documentation update)
- [ ] Type hints added where appropriate (Not applicable for markdown code snippets)

### Quality Checks

```bash
# Not applicable for documentation changes
```

## Performance Impact

- [x] No performance impact

## Breaking Changes

None.

## Documentation

- [ ] Documentation updated in README.md
- [x] API documentation updated
- [x] Examples updated if needed
- [ ] CHANGELOG.md updated

## Security

- [x] Security improvement (Explicitly including `user_id` in examples promotes secure usage patterns from the start.)

## Screenshots/Examples

**Before (example snippet):**
```python
# Available to all agents
context.push("api_status", "healthy")
```

**After (example snippet):**
```python
from syntha import ContextMesh

context = ContextMesh(user_id="user123")
# Available to all agents
context.push("api_status", "healthy")
```

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary (N/A for markdown examples)
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (Manual verification of examples)
- [ ] New and existing unit tests pass locally with my changes (N/A for documentation changes)
- [ ] Any dependent changes have been merged and published

## Additional Notes

The primary goal of this PR is to enhance the developer experience by ensuring that all code examples in the documentation are immediately usable without requiring users to infer missing imports or setup steps.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3282688-05cb-4b22-bab0-c7fe51d929bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3282688-05cb-4b22-bab0-c7fe51d929bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>